### PR TITLE
[Downey / Isaac] PhotosApp Step2 - Photos 라이브러리 활용

### DIFF
--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		22693BBC26086BB300E0DF6D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22693BBA26086BB300E0DF6D /* LaunchScreen.storyboard */; };
 		22A74D9126097FC300B0C680 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A74D9026097FC300B0C680 /* CollectionViewDataSource.swift */; };
 		22A74D942609813100B0C680 /* PhotosCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A74D932609813100B0C680 /* PhotosCollectionView.swift */; };
+		B0EF6BB826098A97001F0DCC /* CustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EF6BB726098A97001F0DCC /* CustomCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		22693BBD26086BB300E0DF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22A74D9026097FC300B0C680 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
 		22A74D932609813100B0C680 /* PhotosCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosCollectionView.swift; sourceTree = "<group>"; };
+		B0EF6BB726098A97001F0DCC /* CustomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +71,7 @@
 				22693BB826086BB300E0DF6D /* Assets.xcassets */,
 				22693BBA26086BB300E0DF6D /* LaunchScreen.storyboard */,
 				22693BBD26086BB300E0DF6D /* Info.plist */,
+				B0EF6BB726098A97001F0DCC /* CustomCell.swift */,
 			);
 			path = PhotosApp;
 			sourceTree = "<group>";
@@ -147,6 +150,7 @@
 				22693BB026086BAF00E0DF6D /* AppDelegate.swift in Sources */,
 				22A74D942609813100B0C680 /* PhotosCollectionView.swift in Sources */,
 				22693BB226086BAF00E0DF6D /* SceneDelegate.swift in Sources */,
+				B0EF6BB826098A97001F0DCC /* CustomCell.swift in Sources */,
 				22A74D9126097FC300B0C680 /* CollectionViewDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
+++ b/PhotosApp/PhotosApp.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		22693BB726086BAF00E0DF6D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22693BB526086BAF00E0DF6D /* Main.storyboard */; };
 		22693BB926086BB300E0DF6D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22693BB826086BB300E0DF6D /* Assets.xcassets */; };
 		22693BBC26086BB300E0DF6D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22693BBA26086BB300E0DF6D /* LaunchScreen.storyboard */; };
+		22A74D9126097FC300B0C680 /* CollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A74D9026097FC300B0C680 /* CollectionViewDataSource.swift */; };
+		22A74D942609813100B0C680 /* PhotosCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A74D932609813100B0C680 /* PhotosCollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +26,8 @@
 		22693BB826086BB300E0DF6D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		22693BBB26086BB300E0DF6D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		22693BBD26086BB300E0DF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		22A74D9026097FC300B0C680 /* CollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDataSource.swift; sourceTree = "<group>"; };
+		22A74D932609813100B0C680 /* PhotosCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosCollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +63,8 @@
 				22693BAF26086BAF00E0DF6D /* AppDelegate.swift */,
 				22693BB126086BAF00E0DF6D /* SceneDelegate.swift */,
 				22693BB326086BAF00E0DF6D /* ViewController.swift */,
+				22A74D9026097FC300B0C680 /* CollectionViewDataSource.swift */,
+				22A74D932609813100B0C680 /* PhotosCollectionView.swift */,
 				22693BB526086BAF00E0DF6D /* Main.storyboard */,
 				22693BB826086BB300E0DF6D /* Assets.xcassets */,
 				22693BBA26086BB300E0DF6D /* LaunchScreen.storyboard */,
@@ -139,7 +145,9 @@
 			files = (
 				22693BB426086BAF00E0DF6D /* ViewController.swift in Sources */,
 				22693BB026086BAF00E0DF6D /* AppDelegate.swift in Sources */,
+				22A74D942609813100B0C680 /* PhotosCollectionView.swift in Sources */,
 				22693BB226086BAF00E0DF6D /* SceneDelegate.swift in Sources */,
+				22A74D9126097FC300B0C680 /* CollectionViewDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Usa-Hr-Ur2">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Usa-Hr-Ur2" customClass="PhotosColectionView" customModule="PhotosApp" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="44" width="390" height="766"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="i2c-n8-iqU">

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="jd1-xB-Ah3">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Photos-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="PhotosApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Usa-Hr-Ur2" customClass="PhotosColectionView" customModule="PhotosApp" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="390" height="766"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="i2c-n8-iqU">
                                     <size key="itemSize" width="80" height="80"/>
@@ -33,6 +33,12 @@
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="bwE-Ax-DdQ">
                                             <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HN2-UE-loc">
+                                                    <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                            </subviews>
                                         </collectionViewCellContentView>
                                     </collectionViewCell>
                                 </cells>
@@ -47,11 +53,30 @@
                             <constraint firstItem="Usa-Hr-Ur2" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="muS-ji-Kpp"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Photos" id="Hcj-aI-dF8"/>
                     <connections>
                         <outlet property="collectionView" destination="Usa-Hr-Ur2" id="aSa-Se-WDk"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="732.30769230769226" y="93.838862559241704"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="BqA-67-AyX">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="jd1-xB-Ah3" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="c4D-Jz-jN7">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="mpe-GR-qWI"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Prh-CJ-Aae" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-196.92307692307691" y="93.838862559241704"/>
         </scene>

--- a/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
+++ b/PhotosApp/PhotosApp/Base.lproj/Main.storyboard
@@ -21,25 +21,28 @@
                                 <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="i2c-n8-iqU">
-                                    <size key="itemSize" width="80" height="80"/>
+                                    <size key="itemSize" width="100" height="100"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="MyCell" id="tVA-C5-bmd">
-                                        <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="MyCell" id="tVA-C5-bmd" customClass="CustomCell" customModule="PhotosApp" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="bwE-Ax-DdQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HN2-UE-loc">
-                                                    <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HN2-UE-loc">
+                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                             </subviews>
                                         </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="imageView" destination="HN2-UE-loc" id="63l-BJ-Ph2"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>

--- a/PhotosApp/PhotosApp/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/CollectionViewDataSource.swift
@@ -1,0 +1,37 @@
+//
+//  CollectionViewDataSource.swift
+//  PhotosApp
+//
+//  Created by Issac on 2021/03/23.
+//
+
+import UIKit
+
+class CollectionViewDataSource: NSObject {
+    
+}
+
+extension CollectionViewDataSource: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 40
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MyCell", for: indexPath)
+        cell.backgroundColor = getRandomColor()
+        return cell
+    }
+    
+    func getRandomColor() -> UIColor{
+        let randomRed:CGFloat = CGFloat(drand48())
+        let randomGreen:CGFloat = CGFloat(drand48())
+        let randomBlue:CGFloat = CGFloat(drand48())
+        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
+    }
+}
+
+extension CollectionViewDataSource: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 80, height: 80)
+    }
+}

--- a/PhotosApp/PhotosApp/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/CollectionViewDataSource.swift
@@ -9,13 +9,14 @@ import UIKit
 import Photos
 
 class CollectionViewDataSource: NSObject {
-    var allPhotos : PHFetchResult<PHAsset>?
+    var allPhotos : PHFetchResult<PHAsset>!
     
 }
 
 extension CollectionViewDataSource: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 5
+        self.allPhotos = PHAsset.fetchAssets(with: nil)
+        return allPhotos.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -24,26 +25,15 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         
-        self.allPhotos = PHAsset.fetchAssets(with: nil)
-        let asset : PHAsset = (self.allPhotos?.object(at: indexPath.item))!
+        let asset : PHAsset = self.allPhotos.object(at: indexPath.item)
         let imageManager = PHCachingImageManager()
-        let option = PHImageRequestOptions()
-        
-        cell.representedAssetIdentifirer = asset.localIdentifier
-        
-        imageManager.requestImage(for: asset, targetSize: CGSize.init(width: 80, height: 80), contentMode: .aspectFit, options: option, resultHandler: { image, _ in
-            print(image)
-            if cell.representedAssetIdentifirer == asset.localIdentifier {
-                cell.imageView.topAnchor.constraint(equalTo: cell.topAnchor).isActive = true
-                cell.imageView.bottomAnchor.constraint(equalTo: cell.bottomAnchor).isActive = true
-                cell.imageView.trailingAnchor.constraint(equalTo: cell.trailingAnchor).isActive = true
-                cell.imageView.leadingAnchor.constraint(equalTo: cell.leadingAnchor).isActive = true
-                cell.imageView.image = image!
-                
-            }
-            
-        })
-        
+        imageManager.requestImage(for: asset,
+                                  targetSize: CGSize.init(width: 100, height: 100),
+                                  contentMode: .aspectFill,
+                                  options: nil,
+                                  resultHandler: { image, _ in
+                                    cell.imageView.image = image!
+                                  })
         cell.backgroundColor = getRandomColor()
         return cell
     }
@@ -58,6 +48,6 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
 
 extension CollectionViewDataSource: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 80, height: 80)
+        return CGSize(width: 100, height: 100)
     }
 }

--- a/PhotosApp/PhotosApp/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/CollectionViewDataSource.swift
@@ -6,18 +6,44 @@
 //
 
 import UIKit
+import Photos
 
 class CollectionViewDataSource: NSObject {
+    var allPhotos : PHFetchResult<PHAsset>?
     
 }
 
 extension CollectionViewDataSource: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 40
+        return 5
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MyCell", for: indexPath)
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MyCell", for: indexPath) as? CustomCell
+        else {
+            return UICollectionViewCell()
+        }
+        
+        self.allPhotos = PHAsset.fetchAssets(with: nil)
+        let asset : PHAsset = (self.allPhotos?.object(at: indexPath.item))!
+        let imageManager = PHCachingImageManager()
+        let option = PHImageRequestOptions()
+        
+        cell.representedAssetIdentifirer = asset.localIdentifier
+        
+        imageManager.requestImage(for: asset, targetSize: CGSize.init(width: 80, height: 80), contentMode: .aspectFit, options: option, resultHandler: { image, _ in
+            print(image)
+            if cell.representedAssetIdentifirer == asset.localIdentifier {
+                cell.imageView.topAnchor.constraint(equalTo: cell.topAnchor).isActive = true
+                cell.imageView.bottomAnchor.constraint(equalTo: cell.bottomAnchor).isActive = true
+                cell.imageView.trailingAnchor.constraint(equalTo: cell.trailingAnchor).isActive = true
+                cell.imageView.leadingAnchor.constraint(equalTo: cell.leadingAnchor).isActive = true
+                cell.imageView.image = image!
+                
+            }
+            
+        })
+        
         cell.backgroundColor = getRandomColor()
         return cell
     }

--- a/PhotosApp/PhotosApp/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/CollectionViewDataSource.swift
@@ -10,7 +10,6 @@ import Photos
 
 class CollectionViewDataSource: NSObject {
     var allPhotos : PHFetchResult<PHAsset>!
-    
 }
 
 extension CollectionViewDataSource: UICollectionViewDataSource {

--- a/PhotosApp/PhotosApp/CustomCell.swift
+++ b/PhotosApp/PhotosApp/CustomCell.swift
@@ -1,0 +1,18 @@
+//
+//  CustomCell.swift
+//  PhotosApp
+//
+//  Created by 이다훈 on 2021/03/23.
+//
+
+import UIKit
+
+class CustomCell: UICollectionViewCell {
+    var imageView : UIImageView = {
+        var imageView = UIImageView()
+        imageView.bounds = CGRect.init(x: 0, y: 0, width: 80, height: 80)
+        return imageView
+    }()
+    var representedAssetIdentifirer : String!
+    
+}

--- a/PhotosApp/PhotosApp/CustomCell.swift
+++ b/PhotosApp/PhotosApp/CustomCell.swift
@@ -8,11 +8,5 @@
 import UIKit
 
 class CustomCell: UICollectionViewCell {
-    var imageView : UIImageView = {
-        var imageView = UIImageView()
-        imageView.bounds = CGRect.init(x: 0, y: 0, width: 80, height: 80)
-        return imageView
-    }()
-    var representedAssetIdentifirer : String!
-    
+    @IBOutlet weak var imageView: UIImageView!
 }

--- a/PhotosApp/PhotosApp/Info.plist
+++ b/PhotosApp/PhotosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>plz, give me photo album</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/PhotosApp/PhotosApp/PhotosCollectionView.swift
+++ b/PhotosApp/PhotosApp/PhotosCollectionView.swift
@@ -1,0 +1,24 @@
+//
+//  PhotosCollectionView.swift
+//  PhotosApp
+//
+//  Created by Issac on 2021/03/23.
+//
+
+import UIKit
+
+class PhotosColectionView: UICollectionView {
+    var collecitonViewDataSource = CollectionViewDataSource()
+    
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        self.dataSource = collecitonViewDataSource
+        self.delegate = collecitonViewDataSource
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.dataSource = collecitonViewDataSource
+        self.delegate = collecitonViewDataSource
+    }
+}

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -12,33 +12,6 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.collectionView.dataSource = self
-        self.collectionView.delegate = self
         
-    }
-}
-
-extension ViewController: UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 40
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MyCell", for: indexPath)
-        cell.backgroundColor = getRandomColor()
-        return cell
-    }
-    
-    func getRandomColor() -> UIColor{
-        let randomRed:CGFloat = CGFloat(drand48())
-        let randomGreen:CGFloat = CGFloat(drand48())
-        let randomBlue:CGFloat = CGFloat(drand48())
-        return UIColor(red: randomRed, green: randomGreen, blue: randomBlue, alpha: 1.0)
-    }
-}
-
-extension ViewController: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 80, height: 80)
     }
 }

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -8,13 +8,48 @@
 import UIKit
 import Photos
 
-class ViewController: UIViewController {
-    @IBOutlet weak var collectionView: UICollectionView!
+class ViewController: UIViewController, PHPhotoLibraryChangeObserver {
+    @IBOutlet weak var collectionView: PhotosColectionView!
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.collectionView.reloadData()
+        PHPhotoLibrary.shared().register(self)
     }
+    
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        var assetCollection = collectionView.collecitonViewDataSource.allPhotos
+        
+        DispatchQueue.main.sync {
+            guard let changes = changeInstance.changeDetails(for: assetCollection!)
+            else {
+                return
+            }
+            
+            assetCollection = changes.fetchResultAfterChanges
+            
+            if changes.hasIncrementalChanges {
+                collectionView.performBatchUpdates({
+                    if let removed = changes.removedIndexes , removed.count > 0 {
+                        collectionView.deleteItems(at: removed.map { IndexPath(item: $0, section:0) })
+                    }
+                    if let inserted = changes.insertedIndexes , inserted.count > 0 {
+                        collectionView.insertItems(at: inserted.map { IndexPath(item: $0, section:0) })
+                    }
+                    if let changed = changes.changedIndexes , changed.count > 0 {
+                        collectionView.reloadItems(at: changed.map { IndexPath(item: $0, section:0) })
+                    }
+                    changes.enumerateMoves { fromIndex, toIndex in
+                        self.collectionView.moveItem(at: IndexPath(item: fromIndex, section: 0),
+                                                     to: IndexPath(item: toIndex, section: 0))
+                    }
+                })
+            } else {
+                collectionView.reloadData()
+            }
+        }
+    }
+    
 }

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -6,12 +6,15 @@
 //
 
 import UIKit
+import Photos
 
 class ViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.collectionView.reloadData()
     }
 }


### PR DESCRIPTION
### 스텝별 작업 목록

 - [x] UINavigationController를 Embed시키고, 타이틀을 'Photos'로 지정한다.
 - [x] PHAsset 프레임워크를 사용해서 사진보관함에 있는 사진 이미지를 Cell에 표시한다.
 - [x] PHCachingImageManager 클래스를 활용해서 썸네일 이미지를 100 x 100 크기로 생성해서 Cell에 표시한다.
 - [x] PHPhotoLibrary 클래스에 사진보관함이 변경되는지 여부를 옵저버로 등록한다.



### 학습 키워드

- `UINavigationController`
- `CollectionViewCell`
- `PHCachingImageManager`
- `PHPhotoLibraryChangeObserver`



### 고민과 해결

- `PHPhotoLibraryChangeObserver` 구현이 가장 시간 소요가 많았는데 `collecionView` 변화에 따른 처리를 구현하는데에 막연했던 것 같습니다. 공식 문서와 블로그를 토대로 구현하게 됐습니다.